### PR TITLE
Prepare new releases

### DIFF
--- a/src/clusterctl/devcontainer-feature.json
+++ b/src/clusterctl/devcontainer-feature.json
@@ -1,14 +1,14 @@
 {
     "name": "Clusterctl",
     "id": "clusterctl",
-    "version": "0.0.7",
+    "version": "0.1.0",
     "description": "The CLI for Cluster API.",
     "options": {
         "version": {
             "type": "string",
             "proposals": [
-                "v1.2.11",
-                "v1.3.5"
+                "v1.4.5",
+                "v1.3.10"
             ],
             "default": "v1.5.0",
             "description": "Select or enter clusterctl version to install."

--- a/src/kubeadm/devcontainer-feature.json
+++ b/src/kubeadm/devcontainer-feature.json
@@ -1,14 +1,14 @@
 {
     "name": "Kubeadm",
     "id": "kubeadm",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Kubeadm, nothing more, nothing less, just the binary.",
     "options": {
         "version": {
             "type": "string",
             "proposals": [
-                "v1.25.8",
-                "v1.26.3"
+                "v1.27.4",
+                "v1.26.7"
             ],
             "default": "v1.28.0",
             "description": "Select or enter kubeadm version to install."

--- a/src/tilt/devcontainer-feature.json
+++ b/src/tilt/devcontainer-feature.json
@@ -1,14 +1,14 @@
 {
     "name": "Tilt",
     "id": "tilt",
-    "version": "0.0.3",
+    "version": "0.1.0",
     "description": "Toolkit for microservice development.",
     "options": {
         "version": {
             "type": "string",
             "proposals": [
                 "v0.31.2",
-                "v0.32.0"
+                "v0.32.4"
             ],
             "default": "v0.33.4",
             "description": "Select or enter tilt version to install."

--- a/test/_global/all_version.sh
+++ b/test/_global/all_version.sh
@@ -18,9 +18,9 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
-check "clusterctl version" clusterctl version | grep "v1.2.11"
-check "kubeadm version" kubeadm version -o short | grep "v1.25.8"
-check "tilt version" tilt version | grep "v0.31.2"
+check "clusterctl version" clusterctl version | grep "v1.4.5"
+check "kubeadm version" kubeadm version -o short | grep "v1.27.4"
+check "tilt version" tilt version | grep "v0.32.4"
 
 # Report result
 # If any of the checks above exited with a non-zero exit code, the test will fail.

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -3,13 +3,13 @@
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
             "clusterctl": {
-                "version": "v1.2.11"
+                "version": "v1.4.5"
             },
             "kubeadm": {
-                "version": "v1.25.8"
+                "version": "v1.27.4"
             },
             "tilt": {
-                "version": "v0.31.2"
+                "version": "v0.32.4"
             }
         }
     }


### PR DESCRIPTION
All feature versions are bumped to v0.1.0.
I use them in my day to day work and rely on them for doing it,
so I think a minor version bump is justified to
show that they are stable and usable.