### PR TITLE
Prepare release

### DIFF
--- a/src/clusterctl/devcontainer-feature.json
+++ b/src/clusterctl/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Clusterctl",
   "id": "clusterctl",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "The CLI for Cluster API.",
   "options": {
     "version": {

--- a/src/kubeadm/devcontainer-feature.json
+++ b/src/kubeadm/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Kubeadm",
   "id": "kubeadm",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Kubeadm, nothing more, nothing less, just the binary.",
   "options": {
     "version": {

--- a/src/kwok/devcontainer-feature.json
+++ b/src/kwok/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "KWOK",
   "id": "kwok",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "KWOK (Kubernetes WithOut Kubelet). This installs both kwok and kwokctl.",
   "options": {
     "version": {

--- a/src/tilt/devcontainer-feature.json
+++ b/src/tilt/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Tilt",
   "id": "tilt",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Toolkit for microservice development.",
   "options": {
     "version": {

--- a/src/yamlfmt/devcontainer-feature.json
+++ b/src/yamlfmt/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "yamlfmt",
   "id": "yamlfmt",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A YAML formatter.",
   "options": {
     "version": {

--- a/test/_global/all_version.sh
+++ b/test/_global/all_version.sh
@@ -18,10 +18,10 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
-check "clusterctl version" clusterctl version | grep "v1.10.4"
-check "kubeadm version" kubeadm version -o short | grep "v1.33.3"
-check "kwok version" kwok --version | grep "v0.5.2"
-check "tilt version" tilt version | grep "v0.35.0"
+check "clusterctl version" clusterctl version | grep "v1.11.1"
+check "kubeadm version" kubeadm version -o short | grep "v1.34.1"
+check "kwok version" kwok --version | grep "v0.7.0"
+check "tilt version" tilt version | grep "v0.35.1"
 check "yamlfmt version" yamlfmt -version | grep "0.17.2"
 
 # Report result

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -3,16 +3,16 @@
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     "features": {
       "clusterctl": {
-        "version": "v1.10.4"
+        "version": "v1.11.1"
       },
       "kubeadm": {
-        "version": "v1.33.3"
+        "version": "v1.34.1"
       },
       "tilt": {
-        "version": "v0.35.0"
+        "version": "v0.35.1"
       },
       "kwok": {
-        "version": "v0.5.2"
+        "version": "v0.7.0"
       },
       "yamlfmt": {
         "version": "v0.17.2"


### PR DESCRIPTION
     - Bump feature versions:
       - clusterctl: 0.1.5 → 0.1.6
       - kubeadm: 0.1.5 → 0.1.6 - kwok: 0.1.4 → 0.1.5 - tilt: 0.1.5 → 0.1.6 - yamlfmt: 0.1.1 → 0.1.2

     - Update test versions to match current defaults:
       - clusterctl: v1.10.4 → v1.11.1
       - kubeadm: v1.33.3 → v1.34.1 - kwok: v0.5.2 → v0.7.0 - tilt: v0.35.0 → v0.35.1 - yamlfmt: 0.17.2 → v0.17.2